### PR TITLE
v0.12.2 - localStorage namespacing & colour scheme update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "[html-common]"]
 	path = [html-common]
 	url = https://github.com/ldpercy/html-common
+	branch = v0.1

--- a/app/turtleApp.js
+++ b/app/turtleApp.js
@@ -64,7 +64,7 @@ class TurtleApp extends HTMLApp {
 		{
 			query: '.colourScheme-selector',
 			type: 'click',
-			listener: this.colourSchemeListener
+			listener: (event) => { ui.colourScheme = event.target.dataset.colourscheme; }
 		},
 		{
 			query: '#form-drawing',
@@ -195,11 +195,6 @@ class TurtleApp extends HTMLApp {
 		}
 	}
 
-	colourSchemeListener(event) {
-		console.debug(event);
-		//event.preventDefault();
-		this.setColourScheme(event.target.dataset.colourscheme);
-	}
 
 	/* saveSettings
 	*/

--- a/app/turtleApp.js
+++ b/app/turtleApp.js
@@ -17,7 +17,7 @@ import { ui } from './view-html-ui.js';
 class TurtleApp extends HTMLApp {
 
 	appName			= 'turtle';
-	appVersion		= 'v0.12.1';
+	appVersion		= 'v0.12.2';
 	projectColour	= 'lightseagreen';
 	appInfo = [`%c
 		Turtle ${this.appVersion} by ldpercy

--- a/app/turtleApp.js
+++ b/app/turtleApp.js
@@ -16,8 +16,9 @@ import { ui } from './view-html-ui.js';
 
 class TurtleApp extends HTMLApp {
 
-	appVersion = 'v0.12.1';
-	projectColour = 'lightseagreen';
+	appName			= 'turtle';
+	appVersion		= 'v0.12.1';
+	projectColour	= 'lightseagreen';
 	appInfo = [`%c
 		Turtle ${this.appVersion} by ldpercy
 		https://github.com/ldpercy/year-clock/releases/tag/${this.appVersion}

--- a/app/turtleApp.js
+++ b/app/turtleApp.js
@@ -132,6 +132,8 @@ class TurtleApp extends HTMLApp {
 
 		const firstLoad = !localStorage[`${this.appName}_documentDOMContentLoaded`];
 
+		ui.colourScheme = localStorage[`${this.appName}_colourScheme`] || 'light';
+
 		this.loadSettings();
 
 		localStorage.setItem(`${this.appName}_documentDOMContentLoaded`, new Date().toISOString());
@@ -222,10 +224,6 @@ class TurtleApp extends HTMLApp {
 
 	loadSettings() {
 		//console.log('Settings loaded');
-
-		if (localStorage[`${this.appName}_colourScheme`]) {
-			this.setColourScheme(localStorage[`${this.appName}_colourScheme`]);
-		}
 
 		if (localStorage[`${this.appName}_settings`]) {
 

--- a/app/turtleApp.js
+++ b/app/turtleApp.js
@@ -62,6 +62,11 @@ class TurtleApp extends HTMLApp {
 			listener: controller.updatePage
 		},
 		{
+			query: '.colourScheme-selector',
+			type: 'click',
+			listener: this.colourSchemeListener
+		},
+		{
 			query: '#form-drawing',
 			type: 'change',
 			listener: svgView.updateDrawing
@@ -125,14 +130,12 @@ class TurtleApp extends HTMLApp {
 	documentDOMContentLoaded() {
 		super.documentDOMContentLoaded();
 
-
-		const firstLoad = !localStorage.appSettings;
+		const firstLoad = !localStorage[`${this.appName}_documentDOMContentLoaded`];
 
 		this.loadSettings();
 
-		localStorage.setItem('documentDOMContentLoaded', new Date().toISOString());
-		sessionStorage.setItem('documentDOMContentLoaded', new Date().toISOString());
-
+		localStorage.setItem(`${this.appName}_documentDOMContentLoaded`, new Date().toISOString());
+		sessionStorage.setItem(`${this.appName}_documentDOMContentLoaded`, new Date().toISOString());
 
 		this.setup();
 
@@ -190,7 +193,11 @@ class TurtleApp extends HTMLApp {
 		}
 	}
 
-
+	colourSchemeListener(event) {
+		console.debug(event);
+		//event.preventDefault();
+		this.setColourScheme(event.target.dataset.colourscheme);
+	}
 
 	/* saveSettings
 	*/
@@ -207,26 +214,31 @@ class TurtleApp extends HTMLApp {
 		//console.log(appSettings);
 
 		const appSettingsJson = JSON.stringify(appSettings);
-		localStorage.setItem('appSettings', appSettingsJson );
-		localStorage.setItem('savedAt', new Date().toISOString());
+		localStorage.setItem(`${this.appName}_settings`, appSettingsJson );
+		localStorage.setItem(`${this.appName}_savedAt`, new Date().toISOString());
 		//.log('Settings saved');
 	}/* saveSettings */
 
 
 	loadSettings() {
 		//console.log('Settings loaded');
-		if (localStorage.appSettings) {
 
-			const appSettings = JSON.parse(localStorage.appSettings);
+		if (localStorage[`${this.appName}_colourScheme`]) {
+			this.setColourScheme(localStorage[`${this.appName}_colourScheme`]);
+		}
+
+		if (localStorage[`${this.appName}_settings`]) {
+
+			const appSettings = JSON.parse(localStorage[`${this.appName}_settings`]);
 			this.populateForm(this.element.turtleForm, appSettings.turtle);
 			this.populateForm(this.element.pageForm, appSettings.page);
 			this.populateForm(this.element.drawingForm, appSettings.drawing);
 		}
 		else {
 			// first load
-
 		}
-		localStorage.setItem('loadedAt', new Date().toISOString());
+
+		localStorage.setItem(`${this.appName}_loadedAt`, new Date().toISOString());
 	}/* loadSettings */
 
 

--- a/app/view-html-ui.js
+++ b/app/view-html-ui.js
@@ -138,6 +138,12 @@ class HTMLUserInterface {
 	}
 
 
+	/** @param {string} colourScheme */
+	set colourScheme(colourScheme) {
+		element.pageForm.colourScheme.value = colourScheme;
+		turtleApp.setColourScheme(colourScheme);
+	}
+
 
 	//
 	//	other

--- a/app/view-svg.js
+++ b/app/view-svg.js
@@ -228,16 +228,6 @@ class SVGView {
 			element.polarGroup.style.display = 'none';
 		}
 
-		if (ui.colourScheme === 'light')
-		{
-			document.body.classList.remove('dark');
-			document.body.classList.add('light');
-		}
-		else {
-			document.body.classList.remove('light');
-			document.body.classList.add('dark');
-		}
-
 		element.cartesianGrid.style.setProperty('opacity', ui.cartesianOpacity);
 		element.polarGrid.style.setProperty('opacity', ui.polarOpacity);
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-colourscheme="light">
 <head>
 	<title>Turtle v0.12.1 by ldpercy</title>
 	<meta charset="utf-8">
@@ -20,7 +20,7 @@
 
 	<script type="module" src="./app/turtleApp.js"></script>
 </head>
-<body class="dark">
+<body>
 
 	<div class="control-group control-left">
 		<form id="form-turtle" tabindex="0">
@@ -73,11 +73,11 @@
 
 			<label class="scheme" title="Colour scheme">
 				<label title="Light scheme">
-					<input type="radio" name="colourScheme" value="light" checked>
+					<input type="radio" name="colourScheme" value="light" checked class="colourScheme-selector" data-colourscheme="light">
 					light
 				</label>
 				<label title="Dark scheme">
-					<input type="radio" name="colourScheme" value="dark">
+					<input type="radio" name="colourScheme" value="dark" class="colourScheme-selector" data-colourscheme="dark">
 					dark
 				</label>
 				<!--

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
 <html lang="en">
 <head>
-	<title>Turtle v0.12.1 by ldpercy</title>
+	<title>Turtle v0.12.2 by ldpercy</title>
 	<meta charset="utf-8">
-	<meta name="description" content="Turtle v0.12.1 by ldpercy - HTML, CSS, SVG, JavaScript">
+	<meta name="description" content="Turtle v0.12.2 by ldpercy - HTML, CSS, SVG, JavaScript">
 	<meta name="color-scheme" content="dark light">
 	<meta name="theme-color" content="lightseagreen"/>
 	<link rel="icon" href="./favicon.svg"/>
@@ -210,7 +210,7 @@
 	<dialog id="dialog-appInfo" closedby="any">
 		<h1>
 			<a href="https://github.com/ldpercy/turtle/">Turtle</a>
-			<a href="https://github.com/ldpercy/turtle/releases/tag/v0.12.1">v0.12.1</a>
+			<a href="https://github.com/ldpercy/turtle/releases/tag/v0.12.2">v0.12.2</a>
 			by <a href="https://github.com/ldpercy/">ldpercy</a>
 		</h1>
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-colourscheme="light">
+<html lang="en">
 <head>
 	<title>Turtle v0.12.1 by ldpercy</title>
 	<meta charset="utf-8">

--- a/page/html.css
+++ b/page/html.css
@@ -49,6 +49,14 @@ html {
 @media (prefers-color-scheme:light) { }
 
 
+html {
+	color-scheme: dark;
+	--accent: var(--accent-dark);
+	accent-color: var(--accent);
+	background-color: var(--page-background-dark);
+	color: white;
+}
+
 
 html[data-colourscheme=light] {
 	color-scheme: light;

--- a/page/html.css
+++ b/page/html.css
@@ -50,7 +50,7 @@ html {
 
 
 
-body.light {
+html[data-colourscheme=light] {
 	color-scheme: light;
 	--accent: var(--accent-light);
 	accent-color: var(--accent);
@@ -69,7 +69,7 @@ body.light {
 	}
 }
 
-body.dark {
+html[data-colourscheme=dark] {
 	color-scheme: dark;
 	--accent: var(--accent-dark);
 	accent-color: var(--accent);

--- a/task/readme.md
+++ b/task/readme.md
@@ -7,7 +7,7 @@ Todo
 
 ### Bugs
 
-* Initial colour scheme loading is still a bit wonky
+
 * Eliminate the 5 extra vertical page pixels
 * Chromium's colour picker goes offscreen - should really be fixed by the vendor
 
@@ -49,7 +49,6 @@ Todo
 In Progress
 -----------
 
-
 * In the process of removing zoom effects on `use:hover` (turtle, marker) with zoom on ordinary SVG which works better. Zoom on `use` is trouble (shadow-dom style, transform origin, browser differences etc).
 * JSDoc type annotations
 * Origin/reset variants - eg one to go to the origin without resetting the heading
@@ -61,6 +60,8 @@ In Progress
 
 Done
 ----
+* localStorage items prefixed with 'turtle_'
+* Initial colour scheme loading resolved for now
 * Keyboard events now filter out `alt` `ctrl` & `meta` combos - [keyboard shortcut bug](<v0/0.12.1 - fix keyboard shortcuts.md>)
 * Fixed the help/info dialog - backdrop, dismissal etc
 * Conversion to use `html-common` submodule

--- a/task/readme.md
+++ b/task/readme.md
@@ -7,12 +7,9 @@ Todo
 
 ### Bugs
 
-
-*
 * Initial colour scheme loading is still a bit wonky
 * Eliminate the 5 extra vertical page pixels
 * Chromium's colour picker goes offscreen - should really be fixed by the vendor
-
 
 
 ### General
@@ -52,7 +49,7 @@ Todo
 In Progress
 -----------
 
-* Keyboard shortcut bug: a prevent default is affecting ctrl-shift-r; plus [other examples](<0.🖮🐛 - fix keyboard shortcuts.md>)
+
 * In the process of removing zoom effects on `use:hover` (turtle, marker) with zoom on ordinary SVG which works better. Zoom on `use` is trouble (shadow-dom style, transform origin, browser differences etc).
 * JSDoc type annotations
 * Origin/reset variants - eg one to go to the origin without resetting the heading
@@ -64,6 +61,7 @@ In Progress
 
 Done
 ----
+* Keyboard events now filter out `alt` `ctrl` & `meta` combos - [keyboard shortcut bug](<v0/0.12.1 - fix keyboard shortcuts.md>)
 * Fixed the help/info dialog - backdrop, dismissal etc
 * Conversion to use `html-common` submodule
 * The weird to-from-origin turtle movement has gone away with the change to translate positioning

--- a/task/v0/0.12 - bring in html-common.md
+++ b/task/v0/0.12 - bring in html-common.md
@@ -91,5 +91,7 @@ Thought I'd changed this over already - maybe in a branch or different proj?
 The colour scheme switching needs to be changed to use `data-colourscheme="foo"` instead of the old class method.
 
 
+* I might switch the unmodified/bare colour scheme to dark - 'turn the lights off' for an initial dark load is more jarring than a 'lights on' for an initial light load
 
+Also colour scheme needs a proper setter so it can combine the UI change with the page change.
 

--- a/task/v0/0.12 - bring in html-common.md
+++ b/task/v0/0.12 - bring in html-common.md
@@ -74,18 +74,18 @@ Maintenance
 [0.12.1 - fix keyboard shortcuts](<0.12.1 - fix keyboard shortcuts.md>)
 
 
-localStorage namespacing
-------------------------
+0.12.2
+------
 
-I'm using for localStorage for turtle app settings, but localStorage is common for an **origin**: scheme/protocol, hostname/domain, and port of the URL.
+### localStorage namespacing
+
+I'm using localStorage for turtle app settings, but localStorage is common for an **origin**: scheme/protocol, hostname/domain, and port of the URL.
 Yesterday realised that this means the turtle app data is visible across my local dev server (at least the way I have it set up now), and similarly across the apps up on github pages.
 So will need to namespace any uses per application.
 I have a little update in the pipeline for html-common/0.1-maintenance, so will use `this.appName` as the namespace for now.
 
 
-
-Colour scheme switching
------------------------
+### Colour scheme switching
 
 Thought I'd changed this over already - maybe in a branch or different proj?
 The colour scheme switching needs to be changed to use `data-colourscheme="foo"` instead of the old class method.
@@ -94,4 +94,11 @@ The colour scheme switching needs to be changed to use `data-colourscheme="foo"`
 * I might switch the unmodified/bare colour scheme to dark - 'turn the lights off' for an initial dark load is more jarring than a 'lights on' for an initial light load
 
 Also colour scheme needs a proper setter so it can combine the UI change with the page change.
+
+
+### html-common maintenance branch
+
+This job requires that to be finished first.
+So need to make sure it's ready to go.
+Also look at the submodule branch/tag question for this.
 

--- a/task/v0/0.12 - bring in html-common.md
+++ b/task/v0/0.12 - bring in html-common.md
@@ -84,4 +84,12 @@ I have a little update in the pipeline for html-common/0.1-maintenance, so will 
 
 
 
+Colour scheme switching
+-----------------------
+
+Thought I'd changed this over already - maybe in a branch or different proj?
+The colour scheme switching needs to be changed to use `data-colourscheme="foo"` instead of the old class method.
+
+
+
 

--- a/task/v0/0.12 - bring in html-common.md
+++ b/task/v0/0.12 - bring in html-common.md
@@ -10,6 +10,7 @@ Bring in html-common submodule and switch over for libs like PlanarSpace, HTMLAp
 2026-03-04		v0.🖮🐛			Maintenance task - keyboard bug
 2026-03-08		v0.12.1			Done
 2026-03-14		v0.12.🐢🥡		Maintenance task - localStorage namespacing
+2026-03-17		v0.12.2			done - localStorage namespacing & colour scheme updates
 ```
 
 
@@ -101,4 +102,17 @@ Also colour scheme needs a proper setter so it can combine the UI change with th
 This job requires that to be finished first.
 So need to make sure it's ready to go.
 Also look at the submodule branch/tag question for this.
+
+### Wrap
+
+I'm doing this a bit fast and loose to see how it goes.
+I've pushed the html-common maintenance release and set a `v0.1` branch pointer.
+I've also set this repo's `.gitmodules` to follow that branch.
+So in theory this should all work, but in practise I half expect to get something wrong.
+
+Anyways, here goes.
+Actual wrap notes:
+* localStorage items are now prefixed with 'turtle_'
+* colour scheme switching has been shifted over to use the `data-colourscheme` technique
+
 

--- a/task/v0/0.12 - bring in html-common.md
+++ b/task/v0/0.12 - bring in html-common.md
@@ -5,8 +5,11 @@ Bring in html-common submodule and switch over for libs like PlanarSpace, HTMLAp
 
 
 ```
-2026-02-27		📽🖧		New task
-2026-03-03		v0.12.0		Done
+2026-02-27		📽🖧			New task
+2026-03-03		v0.12.0			Done
+2026-03-04		v0.🖮🐛			Maintenance task - keyboard bug
+2026-03-08		v0.12.1			Done
+2026-03-14		v0.12.🐢🥡		Maintenance task - localStorage namespacing
 ```
 
 
@@ -52,11 +55,33 @@ I think I'll hold off on more formal testing arrangements so i can get this wrap
 
 
 
-Wrapup v0.12.0
-==============
+v0.12.0 Wrapup
+--------------
 This is pretty much good to go now, will mop anything else up in maintenance.
 
 * New project colour: lightseagreen
 * Added html-common submodule and shifted over to using its versions of core libraries
 * Intro updated a little
 * Upgraded the info dialog a bunch - proper dialog now with background blur and img; added icon
+
+
+߷
+
+
+Maintenance
+===========
+
+[0.12.1 - fix keyboard shortcuts](<0.12.1 - fix keyboard shortcuts.md>)
+
+
+localStorage namespacing
+------------------------
+
+I'm using for localStorage for turtle app settings, but localStorage is common for an **origin**: scheme/protocol, hostname/domain, and port of the URL.
+Yesterday realised that this means the turtle app data is visible across my local dev server (at least the way I have it set up now), and similarly across the apps up on github pages.
+So will need to namespace any uses per application.
+I have a little update in the pipeline for html-common/0.1-maintenance, so will use `this.appName` as the namespace for now.
+
+
+
+


### PR DESCRIPTION
* localStorage items are now prefixed with 'turtle_'
* colour scheme switching has been shifted over to use the `data-colourscheme` technique
